### PR TITLE
feat: add OR logic for comma-separated search terms

### DIFF
--- a/app/api/export/json/route.ts
+++ b/app/api/export/json/route.ts
@@ -173,11 +173,14 @@ export async function GET(request: Request) {
         if (matchesDefaultFilter(textToCheck)) return false;
       }
 
-      // 5. Search filter
+      // 5. Search filter (supports comma-separated OR logic)
       if (search) {
         const searchText =
           `${event.title} ${event.description || ''} ${event.organizer || ''} ${event.location || ''}`.toLowerCase();
-        if (!searchText.includes(search)) return false;
+        const searchTerms = search.split(',').map(term => term.trim()).filter(term => term.length > 0);
+        // Event must match at least one search term (OR logic)
+        const matchesAnyTerm = searchTerms.some(term => searchText.includes(term));
+        if (!matchesAnyTerm) return false;
       }
 
       // 6. Date filter


### PR DESCRIPTION
## Description
Adds support for comma-separated search terms with OR logic in the `/api/export/json` endpoint.

## Motivation
Currently, users must make multiple API calls to search for events matching different terms (e.g., "film" OR "movie"). This enhancement allows a single request: `?search=film,movie`

## Changes
- Modified search filter in `app/api/export/json/route.ts` to split comma-separated terms
- Events now match if they contain ANY of the provided search terms (OR logic)
- Matches existing pattern used for `tagsInclude`, `locations`, etc.

## Example Usage
```
GET /api/export/json?search=film,movie
```
Returns events containing "film" OR "movie" in title, description, organizer, or location.

## Testing
- Tested locally with sample queries
- Backward compatible (single term still works as before)