### PR TITLE
Expose Top 30 score fields in JSON export

### DIFF
--- a/app/api/export/json/route.ts
+++ b/app/api/export/json/route.ts
@@ -309,6 +309,14 @@ export async function GET(request: Request) {
       interestedCount: event.interestedCount || null,
       goingCount: event.goingCount || null,
       favoriteCount: event.favoriteCount || 0,
+      // Scoring (used by Top 30 ranking)
+      score: event.score ?? null,
+      scoreRarity: event.scoreRarity ?? null,
+      scoreUnique: event.scoreUnique ?? null,
+      scoreMagnitude: event.scoreMagnitude ?? null,
+      scoreReason: event.scoreReason ?? null,
+      scoreAshevilleWeird: event.scoreAshevilleWeird ?? null,
+      scoreSocial: event.scoreSocial ?? null,
       // Recurring event info
       recurringType: event.recurringType || null,
       recurringEndDate: event.recurringEndDate?.toISOString() || null,


### PR DESCRIPTION
## Summary
- Adds `score`, `scoreRarity`, `scoreUnique`, `scoreMagnitude`, `scoreReason`, `scoreAshevilleWeird`, and `scoreSocial` to the `/api/export/json` response.
- These columns are already loaded by the `SELECT` in this route — they just weren't projected into the response object. No DB or query changes.

## Why
The Top 30 feature is one of the more useful signals on the site for picking out interesting events. Right now external tooling that consumes the JSON export (e.g. building a weekly Spotify playlist of bands coming to town, custom newsletters, etc.) has to either re-implement scoring locally or scrape the SSR HTML at `/events/top30` — neither great. Exposing the existing scores in the public JSON makes the export self-sufficient for ranking.

## Test plan
- [ ] CI passes (lint + typecheck + prettier)
- [ ] `curl https://www.avlgo.com/api/export/json | jq '.events[0] | keys'` shows the new score fields after deploy
- [ ] Existing consumers unaffected (purely additive — no removed/renamed fields)